### PR TITLE
First working version of JSON Schema validation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: JSON Schema Validation
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   validation:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,21 @@
+name: JSON Schema Validation
+
+on: [push]
+
+jobs:
+  validation:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Install dependencies
+      run: |
+        cd tools/validation
+        npm install
+    - name: Run validation
+      run: node tools/validation/validate.js
+      env:
+        CI: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules/
-package-lock.json

--- a/encryption/frodo/frodo.yaml
+++ b/encryption/frodo/frodo.yaml
@@ -3,11 +3,11 @@ category: lattice
 year:
     paper: 2016
     candidate: 2017
-problems: |
-    LWE (details tbd)
-state: null
+problems:
+    - assumption: LWE
+stateful: false
 nist round: 2
-inventors:
+authors:
   - Erdem Alkim
   - Joppe W. Bos
   - Léo Ducas

--- a/encryption/frodo/frodokem-aes/impl/avx2.yaml
+++ b/encryption/frodo/frodokem-aes/impl/avx2.yaml
@@ -4,7 +4,7 @@ platform: c
 dependencies:
   - OpenSSL
 side channel guarding:
-  branching: yes
+  branching: true
 hardware features:
   - aes-ni
   - avx2

--- a/encryption/frodo/frodokem-aes/impl/opt-openssl.yaml
+++ b/encryption/frodo/frodokem-aes/impl/opt-openssl.yaml
@@ -4,7 +4,7 @@ platform: c
 dependencies:
   - OpenSSL
 side channel guarding:
-  branching: yes
+  branching: true
 hardware features: #TODO how do we encode "or"?
   - aes-ni
   - neon

--- a/encryption/frodo/frodokem-aes/impl/opt-plaincaes.yaml
+++ b/encryption/frodo/frodokem-aes/impl/opt-plaincaes.yaml
@@ -2,4 +2,4 @@ name: Optimized, using plain C AES
 type: optimized
 platform: c
 side channel guarding:
-  branching: yes
+  branching: true

--- a/encryption/frodo/frodokem-aes/impl/ref.yaml
+++ b/encryption/frodo/frodokem-aes/impl/ref.yaml
@@ -1,9 +1,9 @@
-description: Reference
+name: Reference
 type: reference
 platform: c
 dependencies:
   - OpenSSL
 side channel guarding:
-  branching: yes
+  branching: true
 hardware features:
   - aes-ni

--- a/encryption/kyber/ccakem/bench/avx2_512_haswell.yaml
+++ b/encryption/kyber/ccakem/bench/avx2_512_haswell.yaml
@@ -1,8 +1,8 @@
 impl: avx2
-param: 512
+param: "512"
 platform: Intel Core i7-4770K (Haswell)
 timings:
   unit: cycles
   gen: 55160
-  enc: 75680
-  dec: 74428
+  enc/sign: 75680
+  dec/val: 74428

--- a/encryption/kyber/ccakem/bench/ref_512_haswell.yaml
+++ b/encryption/kyber/ccakem/bench/ref_512_haswell.yaml
@@ -1,8 +1,8 @@
 impl: ref
-param: 512
+param: "512"
 platform: Intel Core i7-4770K (Haswell)
 timings:
   unit: cycles
   gen: 141872
-  enc: 205468
-  dec: 246040
+  enc/sign: 205468
+  dec/val: 246040

--- a/encryption/kyber/ccakem/impl/avx2.yaml
+++ b/encryption/kyber/ccakem/impl/avx2.yaml
@@ -1,8 +1,8 @@
-description: AVX2
+name: AVX2
 platform: c
 type: optimized
 side channel guarding:
-  branching: yes
+  branching: true
   timing: unknown
   timing_comment: Assumed, but not verified
 hardware features:

--- a/encryption/kyber/ccakem/impl/ref.yaml
+++ b/encryption/kyber/ccakem/impl/ref.yaml
@@ -1,8 +1,8 @@
-description: Reference
+name: Reference
 platform: c
 type: reference
 side channel guarding:
-  branching: yes
+  branching: true
   timing: unknown
   timing_comment: Assumed, but not verified
 hardware features: []

--- a/encryption/kyber/ccakem/param/512.yaml
+++ b/encryption/kyber/ccakem/param/512.yaml
@@ -7,5 +7,5 @@ failure probability: -145
 sizes:
     sk: 1632
     pk: 736
-    ct: 800
+    ct/sig: 800
     msg: 32

--- a/encryption/kyber/kyber.yaml
+++ b/encryption/kyber/kyber.yaml
@@ -13,9 +13,10 @@ authors:
   - Peter Schwabe
   - Gregor Seiler
   - Damien Stehlé
-problems: |
-    M-LWE (tight ROM reduction, non-tight QROM reduction)
-state: null
+problems:
+    - assumption: M-LWE
+      comment: tight ROM reduction, no-tight QROM reduction
+stateful: false
 nist round: 2
 sources:
   - NIST Submission Paper

--- a/schema/benchmark.json
+++ b/schema/benchmark.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "$id": "benchmark.json#",
+    "type": "object",
+    "properties": {
+        "impl": {
+            "type": "string"
+        },
+        "param": {
+            "type": "string"
+        },
+        "platform": {
+            "type": "string"
+        },
+        "timings": {
+            "type": "object",
+            "properties": {
+                "unit": {
+                    "type": "string",
+                    "enum": [
+                        "cycles",
+                        "ms",
+                        "ns"
+                    ]
+                },
+                "gen": {
+                    "type": "number"
+                },
+                "enc/sign": {
+                    "type": "number"
+                },
+                "dec/val": {
+                    "type": "number"
+                }
+            },
+            "additionalProperties": false
+        },
+        "memory requirements": {
+            "type": "object",
+            "properties": {
+                "gen": {
+                    "type": "integer"
+                },
+                "enc/sign": {
+                    "type": "integer"
+                },
+                "dec/val": {
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "impl",
+        "param"
+    ]
+}

--- a/schema/flavor.json
+++ b/schema/flavor.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "$id": "flavor.json#",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "type": {
+            "type": "string",
+            "enum": [
+                "KEM",
+                "PKE",
+                "KTM",
+                "SIG"
+            ]
+        },
+        "security notion": {
+            "type": "string",
+            "enum": [
+                "IND-CPA",
+                "IND-CCA"
+            ]
+        },
+        "number of operations": {
+            "type": "integer",
+            "minimum": 1
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "type",
+        "security notion",
+        "number of operations"
+    ]
+}

--- a/schema/implementation.json
+++ b/schema/implementation.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "$id": "implementation.json#",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "platform": {
+            "type": "string"
+        },
+        "type": {
+            "type": "string",
+            "enum": [
+                "reference",
+                "optimized"
+            ]
+        },
+        "side channel guarding": {
+            "type": "object",
+            "properties": {
+                "branching": {
+                    "type": "boolean"
+                },
+                "timing": {
+                    "type": "string"
+                },
+                "timing_comment": {
+                    "type": "string"
+                }
+            }
+        },
+        "hardware features": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "dependencies": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "platform"
+    ]
+}

--- a/schema/paramset.json
+++ b/schema/paramset.json
@@ -1,0 +1,64 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "$id": "paramset.json#",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "security level": {
+            "type": "object",
+            "properties": {
+                "classical": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "quantum": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "nist category": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 5
+                }
+            },
+            "required": [
+                "classical",
+                "quantum"
+            ]
+        },
+        "failure probability": {
+            "type": "number",
+            "maximum": 0
+        },
+        "sizes": {
+            "type": "object",
+            "properties": {
+                "sk": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "pk": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "msg": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "ct/sig": {
+                    "type": "integer",
+                    "minimum": 1
+                }
+            }
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "name",
+        "security level",
+        "failure probability",
+        "sizes"
+    ]
+}

--- a/schema/scheme.json
+++ b/schema/scheme.json
@@ -1,0 +1,89 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "$id": "scheme.json#",
+    "type": "object",
+    "properties": {
+        "type": {
+            "type": "string",
+            "enum": [
+                "enc",
+                "sig"
+            ]
+        },
+        "name": {
+            "type": "string"
+        },
+        "category": {
+            "type": "string",
+            "enum": [
+                "lattice",
+                "code",
+                "multivariate",
+                "isogeny",
+                "hash"
+            ]
+        },
+        "year": {
+            "type": "object",
+            "properties": {
+                "paper": {
+                    "type": "integer"
+                },
+                "candidate": {
+                    "type": "integer"
+                },
+                "standardization": {
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": false,
+            "minProperties": 1
+        },
+        "authors": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "stateful": {
+            "type": "boolean"
+        },
+        "nist round": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "problems": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "assumption": {
+                        "type": "string"
+                    },
+                    "comment": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "assumption"
+                ]
+            }
+        },
+        "sources": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "type",
+        "name",
+        "category",
+        "year",
+        "authors",
+        "stateful"
+    ]
+}

--- a/tools/validation/package-lock.json
+++ b/tools/validation/package-lock.json
@@ -1,0 +1,72 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "ajv": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+      "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    }
+  }
+}

--- a/tools/validation/package.json
+++ b/tools/validation/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pqdb-validation",
+  "version": "1.0.0",
+  "main": "validate.js",
+  "dependencies": {
+    "ajv": "^6.11.0",
+    "js-yaml": "^3.13.1"
+  },
+  "license": "SEE LICENSE IN ../LICENSE"
+}

--- a/tools/validation/validate.js
+++ b/tools/validation/validate.js
@@ -1,0 +1,100 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml')
+const Ajv = require('ajv');
+const ajv = new Ajv();
+
+if (!exists('schema')) {
+    console.error('Schema folder could not be found. Did you run the script from the root directory?');
+    process.exit(1);
+}
+
+const schemaForScheme = JSON.parse(fs.readFileSync('schema/scheme.json', 'utf-8'));
+const schemaForFlavor = JSON.parse(fs.readFileSync('schema/flavor.json', 'utf-8'));
+const schemaForParam = JSON.parse(fs.readFileSync('schema/paramset.json', 'utf-8'));
+const schemaForImpl = JSON.parse(fs.readFileSync('schema/implementation.json', 'utf-8'));;
+const schemaForBench = JSON.parse(fs.readFileSync('schema/benchmark.json', 'utf-8'));;
+
+
+function exists(file) {
+    try {
+        fs.accessSync(file, 'fs.constants.F_OK');
+    } catch {
+        return false;
+    }
+    return true;
+}
+
+function isValidSchemeDir(rootDirectory, directory) {
+    var fullPath = path.join(rootDirectory, directory);
+    console.log(fullPath);
+
+    var schemeFile = path.join(fullPath, directory + '.yaml');
+    if (!exists(schemeFile)) {
+        console.error('Scheme file ' + schemeFile + ' is not present.');
+        return false;
+    }
+
+    console.log(schemeFile);
+    var scheme = yaml.load(fs.readFileSync(schemeFile));
+    scheme.type = (rootDirectory.endsWith('encryption')) ? 'enc' : 'sig';
+
+    var isValidScheme = ajv.compile(schemaForScheme);
+    if (!isValidScheme(scheme)) {
+        console.error(isValidScheme.errors);
+        return false;
+    }
+
+    return fs.readdirSync(fullPath).every(
+        flavorDir => !fs.statSync(path.join(fullPath, flavorDir)).isDirectory()
+            || isValidFlavorDir(fullPath, flavorDir)
+    );
+}
+
+function isValidFlavorDir(rootDirectory, directory) {
+    var fullPath = path.join(rootDirectory, directory);
+    console.log(fullPath);
+
+    var flavorFile = path.join(fullPath, directory + '.yaml');
+    if (!exists(flavorFile)) {
+        console.error('Flavor file ' + flavorFile + ' is not present.');
+        return false;
+    }
+    if (!isValidFile(flavorFile, schemaForFlavor)) return false;
+
+    var schemaForDir = {
+        "param": schemaForParam,
+        "impl": schemaForImpl,
+        "bench": schemaForBench
+    };
+
+    return Object.keys(schemaForDir).every(
+        directory => !exists(path.join(fullPath, directory))
+            || fs.readdirSync(path.join(fullPath, directory)).every(
+                file => !fs.statSync(path.join(fullPath, directory, file)).isFile()
+                    || !file.endsWith(".yaml")
+                    || isValidFile(path.join(fullPath, directory, file), schemaForDir[directory])
+            )
+    );
+}
+
+function isValidFile(file, schema) {
+    console.log(file);
+    var isValid = ajv.compile(schema);
+    if (!isValid(yaml.load(fs.readFileSync(file)))) {
+        console.error(isValid.errors);
+        return false;
+    }
+    return true;
+}
+
+function validate() {
+    return ['encryption', 'signatures'].every(
+        rootDir => fs.readdirSync(rootDir).every(
+            schemeDir => !fs.statSync(path.join(rootDir, schemeDir)).isDirectory()
+                || isValidSchemeDir(rootDir, schemeDir)
+        )
+    );
+}
+
+if (!validate()) process.exit(1);

--- a/tools/validation/validate.js
+++ b/tools/validation/validate.js
@@ -98,3 +98,4 @@ function validate() {
 }
 
 if (!validate()) process.exit(1);
+console.log("Validation successfully completed. All files are valid.")


### PR DESCRIPTION
This adds the first working version of JSON Schema validation.

Required dependencies:
```
npm install js-yaml
npm install ajv
```

To run the validation execute
```
node validation/validate.js
```

The schemas are not complete yet but work for the example data.