### PR TITLE
Add NTRU classical security

### DIFF
--- a/encryption/ntru/ntru-kem/param/ntruhps2048509.yaml
+++ b/encryption/ntru/ntru-kem/param/ntruhps2048509.yaml
@@ -1,6 +1,5 @@
 name: NTRU-HPS-2048-509
 security level:
-  classical: 0
   quantum: 105
   nist category: 0
   comment: >-

--- a/encryption/ntru/ntru-kem/param/ntruhps2048509.yaml
+++ b/encryption/ntru/ntru-kem/param/ntruhps2048509.yaml
@@ -1,10 +1,12 @@
 name: NTRU-HPS-2048-509
 security level:
+  classical: 0
   quantum: 105
   nist category: 0
   comment: >-
     Assuming a non-local model of computation.
-    (With a local model: 139 bits quantum security, category 1)
+    (With a local model: 139 bits quantum security, 128 bits classical security, category 1).
+    Classical security is derived from the NIST security level.
 sizes:
   sk: 935
   pk: 699

--- a/encryption/ntru/ntru-kem/param/ntruhps2048509.yaml
+++ b/encryption/ntru/ntru-kem/param/ntruhps2048509.yaml
@@ -4,8 +4,8 @@ security level:
   nist category: 0
   comment: >-
     Assuming a non-local model of computation.
+    Classical security is derived from the corresponding NIST category.
     (With a local model: 139 bits quantum security, 128 bits classical security, category 1).
-    Classical security is derived from the NIST security level.
 sizes:
   sk: 935
   pk: 699

--- a/encryption/ntru/ntru-kem/param/ntruhps2048677.yaml
+++ b/encryption/ntru/ntru-kem/param/ntruhps2048677.yaml
@@ -5,8 +5,8 @@ security level:
   nist category: 1
   comment: >-
     Assuming a non-local model of computation.
+    Classical security is derived from the corresponding NIST category.
     (With a local model: 200 bits quantum security, 192 bits classical security, category 3)
-    Classical security is derived from the NIST security level.
 sizes:
   sk: 1234
   pk: 930

--- a/encryption/ntru/ntru-kem/param/ntruhps2048677.yaml
+++ b/encryption/ntru/ntru-kem/param/ntruhps2048677.yaml
@@ -1,10 +1,12 @@
 name: NTRU-HPS-2048-677
 security level:
+  classical: 128
   quantum: 144
   nist category: 1
   comment: >-
     Assuming a non-local model of computation.
-    (With a local model: 200 bits quantum security, category 3)
+    (With a local model: 200 bits quantum security, 192 bits classical security, category 3)
+    Classical security is derived from the NIST security level.
 sizes:
   sk: 1234
   pk: 930

--- a/encryption/ntru/ntru-kem/param/ntruhps4096821.yaml
+++ b/encryption/ntru/ntru-kem/param/ntruhps4096821.yaml
@@ -5,8 +5,8 @@ security level:
   nist category: 3
   comment: >-
     Assuming a non-local model of computation.
+    Classical security is derived from the corresponding NIST category.
     (With a local model: 253 bits quantum security, 256 bits classical security, category 5)
-    Classical security is derived from the NIST security level.
 sizes:
   sk: 1590
   pk: 1230

--- a/encryption/ntru/ntru-kem/param/ntruhps4096821.yaml
+++ b/encryption/ntru/ntru-kem/param/ntruhps4096821.yaml
@@ -1,10 +1,12 @@
 name: NTRU-HPS-4096-821
 security level:
+  classical: 192
   quantum: 178
   nist category: 3
   comment: >-
     Assuming a non-local model of computation.
-    (With a local model: 253 bits quantum security, category 5)
+    (With a local model: 253 bits quantum security, 256 bits classical security, category 5)
+    Classical security is derived from the NIST security level.
 sizes:
   sk: 1590
   pk: 1230

--- a/encryption/ntru/ntru-kem/param/ntruhrss701.yaml
+++ b/encryption/ntru/ntru-kem/param/ntruhrss701.yaml
@@ -1,10 +1,12 @@
 name: NTRU-HRSS-701
 security level:
+  classical: 128
   quantum: 134
   nist category: 1
   comment: >-
     Assuming a non-local model of computation.
-    (With a local model: 185 bits quantum security, category 3)
+    (With a local model: 185 bits quantum security, 192 bits classical security, category 3)
+    Classical security is derived from the NIST security level.
 sizes:
   sk: 1450
   pk: 1138

--- a/encryption/ntru/ntru-kem/param/ntruhrss701.yaml
+++ b/encryption/ntru/ntru-kem/param/ntruhrss701.yaml
@@ -5,8 +5,8 @@ security level:
   nist category: 1
   comment: >-
     Assuming a non-local model of computation.
+    Classical security is derived from the corresponding NIST category.
     (With a local model: 185 bits quantum security, 192 bits classical security, category 3)
-    Classical security is derived from the NIST security level.
 sizes:
   sk: 1450
   pk: 1138


### PR DESCRIPTION
Classical security estimations are added. Since the submission doesn't
state the classical security directly, the numbers are derived from the
NIST security levels.

NTRUHPS2058509 has no classical security bits since is has NIST level `0` with the non-local model of computation. 

Closes #151