### PR TITLE
Add all XMSS and XMSS^MT parameter sets

### DIFF
--- a/misc/scripts/xmss-param.py
+++ b/misc/scripts/xmss-param.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# -*- coding: utf8 -*-
+
+import yaml
+from collections import namedtuple
+from math import *
+
+Param = namedtuple('Param', 'name hash hashlen n w len h d')
+Param.mt = property(lambda self: self.d > 1)
+
+_params = ( # source: RFC8391
+     ("XMSS-SHA2_10_256",       "SHA2",  256, 32, 16,  67, 10,  1),
+     ("XMSS-SHA2_16_256",       "SHA2",  256, 32, 16,  67, 16,  1),
+     ("XMSS-SHA2_20_256",       "SHA2",  256, 32, 16,  67, 20,  1),
+     ("XMSS-SHA2_10_512",       "SHA2",  512, 64, 16, 131, 10,  1),
+     ("XMSS-SHA2_16_512",       "SHA2",  512, 64, 16, 131, 16,  1),
+     ("XMSS-SHA2_20_512",       "SHA2",  512, 64, 16, 131, 20,  1),
+     ("XMSS-SHAKE_10_256",      "SHAKE", 128, 32, 16,  67, 10,  1),
+     ("XMSS-SHAKE_16_256",      "SHAKE", 128, 32, 16,  67, 16,  1),
+     ("XMSS-SHAKE_20_256",      "SHAKE", 128, 32, 16,  67, 20,  1),
+     ("XMSS-SHAKE_10_512",      "SHAKE", 256, 64, 16, 131, 10,  1),
+     ("XMSS-SHAKE_16_512",      "SHAKE", 256, 64, 16, 131, 16,  1),
+     ("XMSS-SHAKE_20_512",      "SHAKE", 256, 64, 16, 131, 20,  1),
+     ("XMSSMT-SHA2_20/2_256",   "SHA2",  256, 32, 16,  67, 20,  2),
+     ("XMSSMT-SHA2_20/4_256",   "SHA2",  256, 32, 16,  67, 20,  4),
+     ("XMSSMT-SHA2_40/2_256",   "SHA2",  256, 32, 16,  67, 40,  2),
+     ("XMSSMT-SHA2_40/4_256",   "SHA2",  256, 32, 16,  67, 40,  4),
+     ("XMSSMT-SHA2_40/8_256",   "SHA2",  256, 32, 16,  67, 40,  8),
+     ("XMSSMT-SHA2_60/3_256",   "SHA2",  256, 32, 16,  67, 60,  3),
+     ("XMSSMT-SHA2_60/6_256",   "SHA2",  256, 32, 16,  67, 60,  6),
+     ("XMSSMT-SHA2_60/12_256",  "SHA2",  256, 32, 16,  67, 60, 12),
+     ("XMSSMT-SHA2_20/2_512",   "SHA2",  512, 64, 16, 131, 20,  2),
+     ("XMSSMT-SHA2_20/4_512",   "SHA2",  512, 64, 16, 131, 20,  4),
+     ("XMSSMT-SHA2_40/2_512",   "SHA2",  512, 64, 16, 131, 40,  2),
+     ("XMSSMT-SHA2_40/4_512",   "SHA2",  512, 64, 16, 131, 40,  4),
+     ("XMSSMT-SHA2_40/8_512",   "SHA2",  512, 64, 16, 131, 40,  8),
+     ("XMSSMT-SHA2_60/3_512",   "SHA2",  512, 64, 16, 131, 60,  3),
+     ("XMSSMT-SHA2_60/6_512",   "SHA2",  512, 64, 16, 131, 60,  6),
+     ("XMSSMT-SHA2_60/12_512",  "SHA2",  512, 64, 16, 131, 60, 12),
+     ("XMSSMT-SHAKE_20/2_256",  "SHAKE", 128, 32, 16,  67, 20,  2),
+     ("XMSSMT-SHAKE_20/4_256",  "SHAKE", 128, 32, 16,  67, 20,  4),
+     ("XMSSMT-SHAKE_40/2_256",  "SHAKE", 128, 32, 16,  67, 40,  2),
+     ("XMSSMT-SHAKE_40/4_256",  "SHAKE", 128, 32, 16,  67, 40,  4),
+     ("XMSSMT-SHAKE_40/8_256",  "SHAKE", 128, 32, 16,  67, 40,  8),
+     ("XMSSMT-SHAKE_60/3_256",  "SHAKE", 128, 32, 16,  67, 60,  3),
+     ("XMSSMT-SHAKE_60/6_256",  "SHAKE", 128, 32, 16,  67, 60,  6),
+     ("XMSSMT-SHAKE_60/12_256", "SHAKE", 128, 32, 16,  67, 60, 12),
+     ("XMSSMT-SHAKE_20/2_512",  "SHAKE", 256, 64, 16, 131, 20,  2),
+     ("XMSSMT-SHAKE_20/4_512",  "SHAKE", 256, 64, 16, 131, 20,  4),
+     ("XMSSMT-SHAKE_40/2_512",  "SHAKE", 256, 64, 16, 131, 40,  2),
+     ("XMSSMT-SHAKE_40/4_512",  "SHAKE", 256, 64, 16, 131, 40,  4),
+     ("XMSSMT-SHAKE_40/8_512",  "SHAKE", 256, 64, 16, 131, 40,  8),
+     ("XMSSMT-SHAKE_60/3_512",  "SHAKE", 256, 64, 16, 131, 60,  3),
+     ("XMSSMT-SHAKE_60/6_512",  "SHAKE", 256, 64, 16, 131, 60,  6),
+     ("XMSSMT-SHAKE_60/12_512", "SHAKE", 256, 64, 16, 131, 60, 12),
+)
+PARAMS = {x[0]: Param(*x) for x in _params}
+
+def generate(ps):
+    if isinstance(ps, str):
+        ps = PARAMS[ps]
+
+    _comment = ("Secret key size vastly depends on the implementation, and can be "
+                "balanced against signing time. The given value is when using "
+                "`treehash` from BDS08, estimated. "
+                "Source: https://crypto.stackexchange.com/a/77292 . "
+                "Absolute minimum is {min_sk} bytes.")
+
+    # source: https://crypto.stackexchange.com/a/77292
+    bds_sk = ceil((ps.n * (4 + (2*ps.d + 1)*(floor(3.5*ps.h/ps.d) - 4)) + 9*ps.h)/8)
+    min_sk = 4 * ps.n + ceil(ps.h/8)
+
+    return {
+        'name': ps.name,
+        'security level': {
+            'classical': ps.n*8,
+            'quantum': ps.n*8 // 2,
+        },
+        'number of operations': '2^{}'.format(ps.h),
+        'failure probability': 0,
+        'sizes': {
+            'sk': bds_sk,
+            'pk': 2*ps.n + 4, # source: RFC8391
+            'ct|sig': 4 + ps.n + (ps.len + ps.h) * ps.n, # source: RFC8391
+            'msg': ps.n * 8,
+            'comment': _comment.format(min_sk=min_sk),
+        },
+    }
+
+def make_filename(ps, prefix='signatures/xmss/'):
+    if isinstance(ps, str):
+        ps = PARAMS[ps]
+
+    if ps.mt:
+        t = '{prefix}xmss-{hash}/param/xmssmt-{hash}-{h}-{d}-{n8}.yaml'
+    else:
+        t = '{prefix}xmss-{hash}/param/xmss-{hash}-{h}-{n8}.yaml'
+
+    return t.format(
+        prefix=prefix,
+        hash=ps.hash.lower(),
+        h=ps.h,
+        n8=ps.n * 8,
+        d=ps.d,
+    )
+
+if __name__ == '__main__':
+    import sys
+    if sys.argv[1:]:
+        if sys.argv[1] == '--write':
+            for p in PARAMS:
+                with open(make_filename(p), 'w') as f:
+                    yaml.dump(generate(p), f, sort_keys=False)
+        else:
+            yaml.dump(generate(sys.argv[1]), sys.stdout, sort_keys=False)
+    else:
+        for p in PARAMS:
+            print(p)

--- a/signatures/xmss/xmss-sha2/param/xmss-sha2-10-256.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmss-sha2-10-256.yaml
@@ -1,12 +1,14 @@
 name: XMSS-SHA2_10_256
 security level:
-    classical: 256
-    quantum: 128
+  classical: 256
+  quantum: 128
 number of operations: 2^10
 failure probability: 0
 sizes:
-    sk: 3116
-    pk: 68
-    ct|sig: 2500
-    msg: 256
-    comment: "value for `sk` depends vastly on the implementation, and can be balanced against signing time. The given value is when using `treehash` from BDS08, estimated. Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 132 bytes."
+  sk: 400
+  pk: 68
+  ct|sig: 2500
+  msg: 256
+  comment: 'Secret key size vastly depends on the implementation, and can be balanced
+    against signing time. The given value is when using `treehash` from BDS08, estimated.
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 130 bytes.'

--- a/signatures/xmss/xmss-sha2/param/xmss-sha2-10-512.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmss-sha2-10-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSS-SHA2_10_512
 security level:
-  classical: 256
-  quantum: 128
-number of operations: 2^20
+  classical: 512
+  quantum: 256
+number of operations: 2^10
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 788
+  pk: 132
+  ct|sig: 9092
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 258 bytes.'

--- a/signatures/xmss/xmss-sha2/param/xmss-sha2-16-256.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmss-sha2-16-256.yaml
@@ -1,12 +1,14 @@
 name: XMSS-SHA2_16_256
 security level:
-    classical: 256
-    quantum: 128
+  classical: 256
+  quantum: 128
 number of operations: 2^16
 failure probability: 0
 sizes:
-    sk: 5138
-    pk: 68
-    ct|sig: 2692
-    msg: 256
-    comment: "value for `sk` depends vastly on the implementation, and can be balanced against signing time. The given value is when using `treehash` from BDS08, estimated. Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 132 bytes."
+  sk: 658
+  pk: 68
+  ct|sig: 2692
+  msg: 256
+  comment: 'Secret key size vastly depends on the implementation, and can be balanced
+    against signing time. The given value is when using `treehash` from BDS08, estimated.
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 130 bytes.'

--- a/signatures/xmss/xmss-sha2/param/xmss-sha2-16-512.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmss-sha2-16-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSS-SHA2_16_512
 security level:
-  classical: 256
-  quantum: 128
-number of operations: 2^20
+  classical: 512
+  quantum: 256
+number of operations: 2^16
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 1298
+  pk: 132
+  ct|sig: 9476
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 258 bytes.'

--- a/signatures/xmss/xmss-sha2/param/xmss-sha2-20-512.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmss-sha2-20-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSS-SHA2_20_512
 security level:
-  classical: 256
-  quantum: 128
+  classical: 512
+  quantum: 256
 number of operations: 2^20
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 1639
+  pk: 132
+  ct|sig: 9732
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 259 bytes.'

--- a/signatures/xmss/xmss-sha2/param/xmssmt-sha2-20-2-256.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmssmt-sha2-20-2-256.yaml
@@ -1,11 +1,11 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHA2_20/2_256
 security level:
   classical: 256
   quantum: 128
 number of operations: 2^20
 failure probability: 0
 sizes:
-  sk: 831
+  sk: 659
   pk: 68
   ct|sig: 2820
   msg: 256

--- a/signatures/xmss/xmss-sha2/param/xmssmt-sha2-20-2-512.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmssmt-sha2-20-2-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHA2_20/2_512
 security level:
-  classical: 256
-  quantum: 128
+  classical: 512
+  quantum: 256
 number of operations: 2^20
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 1295
+  pk: 132
+  ct|sig: 9732
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 259 bytes.'

--- a/signatures/xmss/xmss-sha2/param/xmssmt-sha2-20-4-256.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmssmt-sha2-20-4-256.yaml
@@ -1,11 +1,11 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHA2_20/4_256
 security level:
   classical: 256
   quantum: 128
 number of operations: 2^20
 failure probability: 0
 sizes:
-  sk: 831
+  sk: 507
   pk: 68
   ct|sig: 2820
   msg: 256

--- a/signatures/xmss/xmss-sha2/param/xmssmt-sha2-20-4-512.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmssmt-sha2-20-4-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHA2_20/4_512
 security level:
-  classical: 256
-  quantum: 128
+  classical: 512
+  quantum: 256
 number of operations: 2^20
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 991
+  pk: 132
+  ct|sig: 9732
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 259 bytes.'

--- a/signatures/xmss/xmss-sha2/param/xmssmt-sha2-40-2-256.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmssmt-sha2-40-2-256.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHA2_40/2_256
 security level:
   classical: 256
   quantum: 128
-number of operations: 2^20
+number of operations: 2^40
 failure probability: 0
 sizes:
-  sk: 831
+  sk: 1381
   pk: 68
-  ct|sig: 2820
+  ct|sig: 3460
   msg: 256
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 133 bytes.'

--- a/signatures/xmss/xmss-sha2/param/xmssmt-sha2-40-2-512.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmssmt-sha2-40-2-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHA2_40/2_512
 security level:
-  classical: 256
-  quantum: 128
-number of operations: 2^20
+  classical: 512
+  quantum: 256
+number of operations: 2^40
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 2717
+  pk: 132
+  ct|sig: 11012
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 261 bytes.'

--- a/signatures/xmss/xmss-sha2/param/xmssmt-sha2-40-4-256.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmssmt-sha2-40-4-256.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHA2_40/4_256
 security level:
   classical: 256
   quantum: 128
-number of operations: 2^20
+number of operations: 2^40
 failure probability: 0
 sizes:
-  sk: 831
+  sk: 1177
   pk: 68
-  ct|sig: 2820
+  ct|sig: 3460
   msg: 256
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 133 bytes.'

--- a/signatures/xmss/xmss-sha2/param/xmssmt-sha2-40-4-512.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmssmt-sha2-40-4-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHA2_40/4_512
 security level:
-  classical: 256
-  quantum: 128
-number of operations: 2^20
+  classical: 512
+  quantum: 256
+number of operations: 2^40
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 2309
+  pk: 132
+  ct|sig: 11012
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 261 bytes.'

--- a/signatures/xmss/xmss-sha2/param/xmssmt-sha2-40-8-256.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmssmt-sha2-40-8-256.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHA2_40/8_256
 security level:
   classical: 256
   quantum: 128
-number of operations: 2^20
+number of operations: 2^40
 failure probability: 0
 sizes:
-  sk: 831
+  sk: 945
   pk: 68
-  ct|sig: 2820
+  ct|sig: 3460
   msg: 256
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 133 bytes.'

--- a/signatures/xmss/xmss-sha2/param/xmssmt-sha2-40-8-512.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmssmt-sha2-40-8-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHA2_40/8_512
 security level:
-  classical: 256
-  quantum: 128
-number of operations: 2^20
+  classical: 512
+  quantum: 256
+number of operations: 2^40
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 1845
+  pk: 132
+  ct|sig: 11012
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 261 bytes.'

--- a/signatures/xmss/xmss-sha2/param/xmssmt-sha2-60-12-256.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmssmt-sha2-60-12-256.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHA2_60/12_256
 security level:
   classical: 256
   quantum: 128
-number of operations: 2^20
+number of operations: 2^60
 failure probability: 0
 sizes:
-  sk: 831
+  sk: 1384
   pk: 68
-  ct|sig: 2820
+  ct|sig: 4100
   msg: 256
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 136 bytes.'

--- a/signatures/xmss/xmss-sha2/param/xmssmt-sha2-60-12-512.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmssmt-sha2-60-12-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHA2_60/12_512
 security level:
-  classical: 256
-  quantum: 128
-number of operations: 2^20
+  classical: 512
+  quantum: 256
+number of operations: 2^60
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 2700
+  pk: 132
+  ct|sig: 12292
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 264 bytes.'

--- a/signatures/xmss/xmss-sha2/param/xmssmt-sha2-60-3-256.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmssmt-sha2-60-3-256.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHA2_60/3_256
 security level:
   classical: 256
   quantum: 128
-number of operations: 2^20
+number of operations: 2^60
 failure probability: 0
 sizes:
-  sk: 831
+  sk: 1932
   pk: 68
-  ct|sig: 2820
+  ct|sig: 4100
   msg: 256
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 136 bytes.'

--- a/signatures/xmss/xmss-sha2/param/xmssmt-sha2-60-3-512.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmssmt-sha2-60-3-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHA2_60/3_512
 security level:
-  classical: 256
-  quantum: 128
-number of operations: 2^20
+  classical: 512
+  quantum: 256
+number of operations: 2^60
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 3796
+  pk: 132
+  ct|sig: 12292
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 264 bytes.'

--- a/signatures/xmss/xmss-sha2/param/xmssmt-sha2-60-6-256.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmssmt-sha2-60-6-256.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHA2_60/6_256
 security level:
   classical: 256
   quantum: 128
-number of operations: 2^20
+number of operations: 2^60
 failure probability: 0
 sizes:
-  sk: 831
+  sk: 1696
   pk: 68
-  ct|sig: 2820
+  ct|sig: 4100
   msg: 256
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 136 bytes.'

--- a/signatures/xmss/xmss-sha2/param/xmssmt-sha2-60-6-512.yaml
+++ b/signatures/xmss/xmss-sha2/param/xmssmt-sha2-60-6-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHA2_60/6_512
 security level:
-  classical: 256
-  quantum: 128
-number of operations: 2^20
+  classical: 512
+  quantum: 256
+number of operations: 2^60
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 3324
+  pk: 132
+  ct|sig: 12292
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 264 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmss-shake-10-256.yaml
+++ b/signatures/xmss/xmss-shake/param/xmss-shake-10-256.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSS-SHAKE_10_256
 security level:
   classical: 256
   quantum: 128
-number of operations: 2^20
+number of operations: 2^10
 failure probability: 0
 sizes:
-  sk: 831
+  sk: 400
   pk: 68
-  ct|sig: 2820
+  ct|sig: 2500
   msg: 256
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 130 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmss-shake-10-512.yaml
+++ b/signatures/xmss/xmss-shake/param/xmss-shake-10-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSS-SHAKE_10_512
 security level:
-  classical: 256
-  quantum: 128
-number of operations: 2^20
+  classical: 512
+  quantum: 256
+number of operations: 2^10
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 788
+  pk: 132
+  ct|sig: 9092
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 258 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmss-shake-16-256.yaml
+++ b/signatures/xmss/xmss-shake/param/xmss-shake-16-256.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSS-SHAKE_16_256
 security level:
   classical: 256
   quantum: 128
-number of operations: 2^20
+number of operations: 2^16
 failure probability: 0
 sizes:
-  sk: 831
+  sk: 658
   pk: 68
-  ct|sig: 2820
+  ct|sig: 2692
   msg: 256
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 130 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmss-shake-16-512.yaml
+++ b/signatures/xmss/xmss-shake/param/xmss-shake-16-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSS-SHAKE_16_512
 security level:
-  classical: 256
-  quantum: 128
-number of operations: 2^20
+  classical: 512
+  quantum: 256
+number of operations: 2^16
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 1298
+  pk: 132
+  ct|sig: 9476
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 258 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmss-shake-20-256.yaml
+++ b/signatures/xmss/xmss-shake/param/xmss-shake-20-256.yaml
@@ -1,4 +1,4 @@
-name: XMSS-SHA2_20_256
+name: XMSS-SHAKE_20_256
 security level:
   classical: 256
   quantum: 128

--- a/signatures/xmss/xmss-shake/param/xmss-shake-20-512.yaml
+++ b/signatures/xmss/xmss-shake/param/xmss-shake-20-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSS-SHAKE_20_512
 security level:
-  classical: 256
-  quantum: 128
+  classical: 512
+  quantum: 256
 number of operations: 2^20
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 1639
+  pk: 132
+  ct|sig: 9732
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 259 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmssmt-shake-20-2-256.yaml
+++ b/signatures/xmss/xmss-shake/param/xmssmt-shake-20-2-256.yaml
@@ -1,11 +1,11 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHAKE_20/2_256
 security level:
   classical: 256
   quantum: 128
 number of operations: 2^20
 failure probability: 0
 sizes:
-  sk: 831
+  sk: 659
   pk: 68
   ct|sig: 2820
   msg: 256

--- a/signatures/xmss/xmss-shake/param/xmssmt-shake-20-2-512.yaml
+++ b/signatures/xmss/xmss-shake/param/xmssmt-shake-20-2-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHAKE_20/2_512
 security level:
-  classical: 256
-  quantum: 128
+  classical: 512
+  quantum: 256
 number of operations: 2^20
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 1295
+  pk: 132
+  ct|sig: 9732
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 259 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmssmt-shake-20-4-256.yaml
+++ b/signatures/xmss/xmss-shake/param/xmssmt-shake-20-4-256.yaml
@@ -1,11 +1,11 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHAKE_20/4_256
 security level:
   classical: 256
   quantum: 128
 number of operations: 2^20
 failure probability: 0
 sizes:
-  sk: 831
+  sk: 507
   pk: 68
   ct|sig: 2820
   msg: 256

--- a/signatures/xmss/xmss-shake/param/xmssmt-shake-20-4-512.yaml
+++ b/signatures/xmss/xmss-shake/param/xmssmt-shake-20-4-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHAKE_20/4_512
 security level:
-  classical: 256
-  quantum: 128
+  classical: 512
+  quantum: 256
 number of operations: 2^20
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 991
+  pk: 132
+  ct|sig: 9732
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 259 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmssmt-shake-40-2-256.yaml
+++ b/signatures/xmss/xmss-shake/param/xmssmt-shake-40-2-256.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHAKE_40/2_256
 security level:
   classical: 256
   quantum: 128
-number of operations: 2^20
+number of operations: 2^40
 failure probability: 0
 sizes:
-  sk: 831
+  sk: 1381
   pk: 68
-  ct|sig: 2820
+  ct|sig: 3460
   msg: 256
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 133 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmssmt-shake-40-2-512.yaml
+++ b/signatures/xmss/xmss-shake/param/xmssmt-shake-40-2-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHAKE_40/2_512
 security level:
-  classical: 256
-  quantum: 128
-number of operations: 2^20
+  classical: 512
+  quantum: 256
+number of operations: 2^40
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 2717
+  pk: 132
+  ct|sig: 11012
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 261 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmssmt-shake-40-4-256.yaml
+++ b/signatures/xmss/xmss-shake/param/xmssmt-shake-40-4-256.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHAKE_40/4_256
 security level:
   classical: 256
   quantum: 128
-number of operations: 2^20
+number of operations: 2^40
 failure probability: 0
 sizes:
-  sk: 831
+  sk: 1177
   pk: 68
-  ct|sig: 2820
+  ct|sig: 3460
   msg: 256
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 133 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmssmt-shake-40-4-512.yaml
+++ b/signatures/xmss/xmss-shake/param/xmssmt-shake-40-4-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHAKE_40/4_512
 security level:
-  classical: 256
-  quantum: 128
-number of operations: 2^20
+  classical: 512
+  quantum: 256
+number of operations: 2^40
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 2309
+  pk: 132
+  ct|sig: 11012
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 261 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmssmt-shake-40-8-256.yaml
+++ b/signatures/xmss/xmss-shake/param/xmssmt-shake-40-8-256.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHAKE_40/8_256
 security level:
   classical: 256
   quantum: 128
-number of operations: 2^20
+number of operations: 2^40
 failure probability: 0
 sizes:
-  sk: 831
+  sk: 945
   pk: 68
-  ct|sig: 2820
+  ct|sig: 3460
   msg: 256
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 133 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmssmt-shake-40-8-512.yaml
+++ b/signatures/xmss/xmss-shake/param/xmssmt-shake-40-8-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHAKE_40/8_512
 security level:
-  classical: 256
-  quantum: 128
-number of operations: 2^20
+  classical: 512
+  quantum: 256
+number of operations: 2^40
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 1845
+  pk: 132
+  ct|sig: 11012
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 261 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmssmt-shake-60-12-256.yaml
+++ b/signatures/xmss/xmss-shake/param/xmssmt-shake-60-12-256.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHAKE_60/12_256
 security level:
   classical: 256
   quantum: 128
-number of operations: 2^20
+number of operations: 2^60
 failure probability: 0
 sizes:
-  sk: 831
+  sk: 1384
   pk: 68
-  ct|sig: 2820
+  ct|sig: 4100
   msg: 256
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 136 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmssmt-shake-60-12-512.yaml
+++ b/signatures/xmss/xmss-shake/param/xmssmt-shake-60-12-512.yaml
@@ -1,0 +1,14 @@
+name: XMSSMT-SHAKE_60/12_512
+security level:
+  classical: 512
+  quantum: 256
+number of operations: 2^60
+failure probability: 0
+sizes:
+  sk: 2700
+  pk: 132
+  ct|sig: 12292
+  msg: 512
+  comment: 'Secret key size vastly depends on the implementation, and can be balanced
+    against signing time. The given value is when using `treehash` from BDS08, estimated.
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 264 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmssmt-shake-60-3-256.yaml
+++ b/signatures/xmss/xmss-shake/param/xmssmt-shake-60-3-256.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHAKE_60/3_256
 security level:
   classical: 256
   quantum: 128
-number of operations: 2^20
+number of operations: 2^60
 failure probability: 0
 sizes:
-  sk: 831
+  sk: 1932
   pk: 68
-  ct|sig: 2820
+  ct|sig: 4100
   msg: 256
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 136 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmssmt-shake-60-3-512.yaml
+++ b/signatures/xmss/xmss-shake/param/xmssmt-shake-60-3-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHAKE_60/3_512
 security level:
-  classical: 256
-  quantum: 128
-number of operations: 2^20
+  classical: 512
+  quantum: 256
+number of operations: 2^60
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 3796
+  pk: 132
+  ct|sig: 12292
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 264 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmssmt-shake-60-6-256.yaml
+++ b/signatures/xmss/xmss-shake/param/xmssmt-shake-60-6-256.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHAKE_60/6_256
 security level:
   classical: 256
   quantum: 128
-number of operations: 2^20
+number of operations: 2^60
 failure probability: 0
 sizes:
-  sk: 831
+  sk: 1696
   pk: 68
-  ct|sig: 2820
+  ct|sig: 4100
   msg: 256
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 136 bytes.'

--- a/signatures/xmss/xmss-shake/param/xmssmt-shake-60-6-512.yaml
+++ b/signatures/xmss/xmss-shake/param/xmssmt-shake-60-6-512.yaml
@@ -1,14 +1,14 @@
-name: XMSS-SHA2_20_256
+name: XMSSMT-SHAKE_60/6_512
 security level:
-  classical: 256
-  quantum: 128
-number of operations: 2^20
+  classical: 512
+  quantum: 256
+number of operations: 2^60
 failure probability: 0
 sizes:
-  sk: 831
-  pk: 68
-  ct|sig: 2820
-  msg: 256
+  sk: 3324
+  pk: 132
+  ct|sig: 12292
+  msg: 512
   comment: 'Secret key size vastly depends on the implementation, and can be balanced
     against signing time. The given value is when using `treehash` from BDS08, estimated.
-    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 131 bytes.'
+    Source: https://crypto.stackexchange.com/a/77292 . Absolute minimum is 264 bytes.'

--- a/signatures/xmss/xmss-shake/xmss-shake.yaml
+++ b/signatures/xmss/xmss-shake/xmss-shake.yaml
@@ -1,0 +1,4 @@
+name: XMSS-SHAKE
+description: using SHAKE as hash function
+type: SIG
+security notion: EUF-CMA


### PR DESCRIPTION
I stored XMSS and XMSS^MT as one flavor (because they typically share implementations), but used separate flavors for SHA2 vs SHAKE versions because they probably use slightly different implementations.

Numbers are automatically generated from the values in the RFC.
The script used to do this is included as well (in `misc/scripts/`).
The old values for `sk` included a (small) calculation error and a (large) error due to not converting bits to bytes.