### PR TITLE
[backend] Add code size for pqm4 data

### DIFF
--- a/encryption/bike/bike/impl/pqm4f-bikel1.yaml
+++ b/encryption/bike/bike/impl/pqm4f-bikel1.yaml
@@ -6,3 +6,8 @@ platform: m4
 type: optimized
 hardware features:
 - FPU
+code size:
+  overall: 181503
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/frodo/frodokem-aes/impl/pqm4-frodokem640aes.yaml
+++ b/encryption/frodo/frodokem-aes/impl/pqm4-frodokem640aes.yaml
@@ -4,3 +4,8 @@ links:
 - https://github.com/mupq/pqm4/tree/master/crypto_kem/frodokem640aes/m4
 platform: m4
 type: optimized
+code size:
+  overall: 8568
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/frodo/frodokem-shake/impl/pqm4-frodokem640shake.yaml
+++ b/encryption/frodo/frodokem-shake/impl/pqm4-frodokem640shake.yaml
@@ -4,3 +4,8 @@ links:
 - https://github.com/mupq/pqm4/tree/master/crypto_kem/frodokem640shake/m4
 platform: m4
 type: optimized
+code size:
+  overall: 8644
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/kyber/ccakem-90s/impl/pqm4-kyber1024-90s.yaml
+++ b/encryption/kyber/ccakem-90s/impl/pqm4-kyber1024-90s.yaml
@@ -4,3 +4,8 @@ links:
 - https://github.com/mupq/pqm4/tree/master/crypto_kem/kyber1024-90s/m4
 platform: m4
 type: optimized
+code size:
+  overall: 11976
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/kyber/ccakem-90s/impl/pqm4-kyber512-90s.yaml
+++ b/encryption/kyber/ccakem-90s/impl/pqm4-kyber512-90s.yaml
@@ -4,3 +4,8 @@ links:
 - https://github.com/mupq/pqm4/tree/master/crypto_kem/kyber512-90s/m4
 platform: m4
 type: optimized
+code size:
+  overall: 10932
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/kyber/ccakem-90s/impl/pqm4-kyber768-90s.yaml
+++ b/encryption/kyber/ccakem-90s/impl/pqm4-kyber768-90s.yaml
@@ -4,3 +4,8 @@ links:
 - https://github.com/mupq/pqm4/tree/master/crypto_kem/kyber768-90s/m4
 platform: m4
 type: optimized
+code size:
+  overall: 10848
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/kyber/ccakem/impl/pqm4-kyber1024.yaml
+++ b/encryption/kyber/ccakem/impl/pqm4-kyber1024.yaml
@@ -4,3 +4,8 @@ links:
 - https://github.com/mupq/pqm4/tree/master/crypto_kem/kyber1024/m4
 platform: m4
 type: optimized
+code size:
+  overall: 11696
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/kyber/ccakem/impl/pqm4-kyber512.yaml
+++ b/encryption/kyber/ccakem/impl/pqm4-kyber512.yaml
@@ -4,3 +4,8 @@ links:
 - https://github.com/mupq/pqm4/tree/master/crypto_kem/kyber512/m4
 platform: m4
 type: optimized
+code size:
+  overall: 10720
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/kyber/ccakem/impl/pqm4-kyber768.yaml
+++ b/encryption/kyber/ccakem/impl/pqm4-kyber768.yaml
@@ -4,3 +4,8 @@ links:
 - https://github.com/mupq/pqm4/tree/master/crypto_kem/kyber768/m4
 platform: m4
 type: optimized
+code size:
+  overall: 10872
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/ntru-prime/lprime/impl/pqm4f-ntrulpr761.yaml
+++ b/encryption/ntru-prime/lprime/impl/pqm4f-ntrulpr761.yaml
@@ -6,3 +6,8 @@ platform: m4
 type: optimized
 hardware features:
 - FPU
+code size:
+  overall: 131065
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/ntru-prime/streamlined/impl/pqm4f-sntrup761.yaml
+++ b/encryption/ntru-prime/streamlined/impl/pqm4f-sntrup761.yaml
@@ -6,3 +6,8 @@ platform: m4
 type: optimized
 hardware features:
 - FPU
+code size:
+  overall: 166517
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/ntru/ntru-kem/impl/pqm4f-ntruhps2048509.yaml
+++ b/encryption/ntru/ntru-kem/impl/pqm4f-ntruhps2048509.yaml
@@ -6,3 +6,8 @@ platform: m4
 type: optimized
 hardware features:
 - FPU
+code size:
+  overall: 91656
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/ntru/ntru-kem/impl/pqm4f-ntruhps2048677.yaml
+++ b/encryption/ntru/ntru-kem/impl/pqm4f-ntruhps2048677.yaml
@@ -6,3 +6,8 @@ platform: m4
 type: optimized
 hardware features:
 - FPU
+code size:
+  overall: 154528
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/ntru/ntru-kem/impl/pqm4f-ntruhps4096821.yaml
+++ b/encryption/ntru/ntru-kem/impl/pqm4f-ntruhps4096821.yaml
@@ -6,3 +6,8 @@ platform: m4
 type: optimized
 hardware features:
 - FPU
+code size:
+  overall: 181180
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/ntru/ntru-kem/impl/pqm4f-ntruhrss701.yaml
+++ b/encryption/ntru/ntru-kem/impl/pqm4f-ntruhrss701.yaml
@@ -6,3 +6,8 @@ platform: m4
 type: optimized
 hardware features:
 - FPU
+code size:
+  overall: 157612
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/saber/saberkem-sha3/impl/pqm4f-firesaber.yaml
+++ b/encryption/saber/saberkem-sha3/impl/pqm4f-firesaber.yaml
@@ -6,3 +6,8 @@ platform: m4
 type: optimized
 hardware features:
 - FPU
+code size:
+  overall: 9556
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/saber/saberkem-sha3/impl/pqm4f-lightsaber.yaml
+++ b/encryption/saber/saberkem-sha3/impl/pqm4f-lightsaber.yaml
@@ -6,3 +6,8 @@ platform: m4
 type: optimized
 hardware features:
 - FPU
+code size:
+  overall: 9660
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/saber/saberkem-sha3/impl/pqm4f-saber.yaml
+++ b/encryption/saber/saberkem-sha3/impl/pqm4f-saber.yaml
@@ -6,3 +6,8 @@ platform: m4
 type: optimized
 hardware features:
 - FPU
+code size:
+  overall: 9412
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/sike/sike-shake256/impl/pqm4-sikep434.yaml
+++ b/encryption/sike/sike-shake256/impl/pqm4-sikep434.yaml
@@ -4,3 +4,8 @@ links:
 - https://github.com/mupq/pqm4/tree/master/crypto_kem/sikep434/m4
 platform: m4
 type: optimized
+code size:
+  overall: 29600
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/sike/sike-shake256/impl/pqm4-sikep503.yaml
+++ b/encryption/sike/sike-shake256/impl/pqm4-sikep503.yaml
@@ -4,3 +4,8 @@ links:
 - https://github.com/mupq/pqm4/tree/master/crypto_kem/sikep503/m4
 platform: m4
 type: optimized
+code size:
+  overall: 31576
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/sike/sike-shake256/impl/pqm4-sikep610.yaml
+++ b/encryption/sike/sike-shake256/impl/pqm4-sikep610.yaml
@@ -4,3 +4,8 @@ links:
 - https://github.com/mupq/pqm4/tree/master/crypto_kem/sikep610/m4
 platform: m4
 type: optimized
+code size:
+  overall: 29420
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/encryption/sike/sike-shake256/impl/pqm4-sikep751.yaml
+++ b/encryption/sike/sike-shake256/impl/pqm4-sikep751.yaml
@@ -4,3 +4,8 @@ links:
 - https://github.com/mupq/pqm4/tree/master/crypto_kem/sikep751/m4
 platform: m4
 type: optimized
+code size:
+  overall: 33012
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/signatures/dilithium/dilithium-shake/impl/pqm4-dilithium2.yaml
+++ b/signatures/dilithium/dilithium-shake/impl/pqm4-dilithium2.yaml
@@ -4,3 +4,8 @@ links:
 - https://github.com/mupq/pqm4/tree/master/crypto_sig/dilithium2/m4
 platform: m4
 type: optimized
+code size:
+  overall: 10576
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.

--- a/signatures/dilithium/dilithium-shake/impl/pqm4-dilithium3.yaml
+++ b/signatures/dilithium/dilithium-shake/impl/pqm4-dilithium3.yaml
@@ -4,3 +4,8 @@ links:
 - https://github.com/mupq/pqm4/tree/master/crypto_sig/dilithium3/m4
 platform: m4
 type: optimized
+code size:
+  overall: 10104
+  comment: The code-size measurements only include the code that is provided by the
+    scheme implementation, i.e., exclude common code like hashing or C standard library
+    functions.


### PR DESCRIPTION
I extended the pqm4 script to include the available code size data.